### PR TITLE
Add LVM thinpool support for Docker on CentOS

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -31,9 +31,13 @@ if [ -n "$DEBUG" ]; then
     #printenv
 fi
 
-#Create a virtualenv
-virtualenv VENV
+#Create a virtualenv, don't download new pip/setuptools
+virtualenv --no-download VENV
 . VENV/bin/activate
+
+# This allows pinning pip/setuptools from your own PyPI repo
+pip install $PIP_ARGS -U pip
+pip install $PIP_ARGS -U setuptools
 
 if [ ! -d swarmy ]
 then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,6 +7,14 @@
 set -e
 cd /root
 
+# Directory where we store intermediate steps/arguments/things we want to share
+# between scripts
+if [ ! -d /root/.swarmy ]; then
+    mkdir /root/.swarmy/
+fi
+
+export SWARMYDIR=/root/.swarmy/
+
 #Settings needed to bootstrap and load settings
 #TODO: GIT_BRANCH=${GIT_BRANCH:-master}
 #PIP_ARGS=""

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -27,9 +27,23 @@ fi
 
 export SWARMYDIR=/root/.swarmy/
 
+if [ -z "$DEBUG" ]; then
+    # If we aren't debugging, we just want to have stdout/stderr be redirect to
+    # files instead so that we can check after the fact that things ran
+    # successfully
 
+    # Close STDOUT file descriptor
+    exec 1<&-
+    # Close STDERR FD
+    exec 2<&-
 
-if [ -n "$DEBUG" ]; then
+    # Open STDOUT as $LOG_FILE file for read and write.
+    exec 1<>$SWARMYDIR/log.stdout
+
+    # Redirect STDERR to STDOUT
+    exec 2<>$SWARMYDIR/log.stderr
+else
+    echo "Debug run of swarmy bootstrap.sh"
     set -x
     #printenv
 fi
@@ -106,7 +120,7 @@ if [ -n "$NEXT_SCRIPT" ]; then
     for script in ${URLLIST[@]}; do
         if [ -n "$script" ]; then
             SCRIPT=$(download_next $script .stage2.sh)
-
+            
             source $SCRIPT
 
             if [ -z "$DEBUG" ]; then
@@ -115,9 +129,7 @@ if [ -n "$NEXT_SCRIPT" ]; then
         fi
     done
 else
-    if [ -n "$DEBUG" ]; then
-        echo "No stage 2 provided."
-    fi
+    echo "No stage 2 provided."
 fi
 
 echo "Bootstrap script finished" >> /root/cloud-init-bootstrap.log

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,6 +4,18 @@
 # system log available through the AWS API, or the
 # console.
 
+#Settings needed to bootstrap and load settings
+#TODO: GIT_BRANCH=${GIT_BRANCH:-master}
+#PIP_ARGS=""
+# Can read multiple settings URLS by separating them with a space
+#SETTINGS_URL=""
+#DEBUG=true
+
+# Can be set here, or loaded from s3 settings
+#   Takes a semicolon separated list of scripts to run
+NEXT_SCRIPT=${NEXT_SCRIPT:-""}
+
+
 set -e
 cd /root
 
@@ -15,16 +27,7 @@ fi
 
 export SWARMYDIR=/root/.swarmy/
 
-#Settings needed to bootstrap and load settings
-#TODO: GIT_BRANCH=${GIT_BRANCH:-master}
-#PIP_ARGS=""
-# Can read multiple settings URLS by separating them with a space
-#SETTINGS_URL=""
-#DEBUG=true
 
-# Can be set here, or loaded from s3 settings
-#   Takes a semicolon separated list of scripts to run
-NEXT_SCRIPT=${NEXT_SCRIPT:-""}
 
 if [ -n "$DEBUG" ]; then
     set -x

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -45,9 +45,7 @@ then
     curl -sL https://github.com/Crunch-io/swarmy/tarball/master | tar -xz --strip-components=1 -C swarmy
 fi
 
-cd swarmy
-python setup.py develop $PIP_ARGS
-cd /root
+pip install $PIP_ARGS -e swarmy
 
 function download_next
 {

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,7 @@
 # console.
 
 #Settings needed to bootstrap and load settings
-#TODO: GIT_BRANCH=${GIT_BRANCH:-master}
+GIT_BRANCH=${GIT_BRANCH:-master}
 #PIP_ARGS=""
 # Can read multiple settings URLS by separating them with a space
 #SETTINGS_URL=""
@@ -62,7 +62,17 @@ pip install $PIP_ARGS -U setuptools
 if [ ! -d swarmy ]
 then
     mkdir -p swarmy
-    curl -sL https://github.com/Crunch-io/swarmy/tarball/master | tar -xz --strip-components=1 -C swarmy
+    # Do this in multiple steps so that a failure to download doesn't cause tar
+    # to uncompress partially
+    curl -sL -o swarmy.tar.gz \
+        "https://api.github.com/repos/Crunch-io/swarmy/tarball/${GIT_BRANCH}"
+    if [ $? -gt 0 ]; then
+        echo "Failed to download Swarmy. Refusing to continue."
+        rm -f swarmy.tar.gz
+        exit 1
+    fi
+    tar -xzf swarmy.tar.gz --strip-components=1 -C swarmy
+    rm -f swarmy.tar.gz
 fi
 
 pip install $PIP_ARGS -e swarmy

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,6 +48,9 @@ else
     #printenv
 fi
 
+echo -n "Starting swarmy bootstrap: "
+date
+
 #Create a virtualenv, don't download new pip/setuptools
 virtualenv --no-download VENV
 . VENV/bin/activate
@@ -132,4 +135,5 @@ else
     echo "No stage 2 provided."
 fi
 
-echo "Bootstrap script finished" >> /root/cloud-init-bootstrap.log
+echo -n "Swarmy bootstrap script finished: "
+date

--- a/scripts/dockerthinpool.sh
+++ b/scripts/dockerthinpool.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -e
 
+# This script is meant to be chained after prepephemeral.sh, other scripts like
+# mountephemeral.sh can be used in a chain loaded fashion to then format and
+# mount the new scratchspace that lives on LVM as a logical volume.
+
 VGNAME=${VGNAME:-data}
 DOCKERPERCENT={$DOCKERPERCENT:-50}
 

--- a/scripts/dockerthinpool.sh
+++ b/scripts/dockerthinpool.sh
@@ -1,0 +1,63 @@
+#!/bin/bash -e
+
+VGNAME=${VGNAME:-data}
+DOCKERPERCENT={$DOCKERPERCENT:-50}
+
+# 1% of the VG is already used by the thinpool meta, so the max number here is
+# 49 assuming you leave DOCKERPERCENT at 50. Start small and you can always
+# grow the logical volume later if necessary (lvextend)
+SCRATCHPERCENT=${SCRATCHPERCENT:-25}
+
+if [ -z "$SWARMYDIR" ]; then
+    echo "SWARMYDIR is not set, this script should be run from swarmy. Cowardly refusing to continue."
+    exit 1
+fi
+
+if [ ! -f "$SWARMYDIR/ephemeraldev" ]; then
+    echo "$SWARMYDIR/ephemeraldev does not exist, not sure where to format/mount"
+    exit 1
+fi
+
+read DEVICE < $SWARMYDIR/ephemeraldev
+
+if [ ! -b $DEVICE ]; then
+    echo "The device \"$DEVICE\" is not a block device. Cowardly refusing to continue"
+    exit 1
+fi
+
+if ! command -v lvm > /dev/null; then
+    echo "Installing required tools..."
+    yum install -y device-mapper-persistent-data lvm2
+fi
+
+if ! vgdisplay $VGNAME; then
+    vgcreate $VGNAME $DEVICE
+    lvcreate --wipesignatures y -n thinpool $VGNAME -l ${DOCKERPERCENT}%VG
+    lvcreate --wipesignatures y -n thinpoolmeta $VGNAME -l 1%VG
+
+    lvconvert -y --zero n -c 512K --thinpool $VGNAME/thinpool --poolmetadata $VGNAME/thinpoolmeta
+
+    cat << EOF > /etc/lvm/profile/docker-thinpool.profile
+activation {
+  thin_pool_autoextend_threshold=80
+  thin_pool_autoextend_percent=20
+}
+EOF
+
+    lvchange --metadataprofile docker-thinpool $VGNAME/thinpool
+    lvs -o+seg_monitor
+
+    echo "Completed creation of the Docker thinpool"
+
+    lvcreate --wipesignatures y -n scratch $VGNAME -l ${SCRATCHPERCENT}%VG
+
+    echo "Created scratch space"
+
+    echo -n "/dev/mapper/$VGNAME-scratch" > $SWARMYDIR/ephemeraldev
+else
+    echo "Physical volume already exists on: $DEVICE"
+    echo "Doing nothing."
+fi
+
+touch $SWARMYDIR/dockerthinpool.run
+

--- a/scripts/mountephemeral.sh
+++ b/scripts/mountephemeral.sh
@@ -1,11 +1,6 @@
 #!/bin/bash -e
 
-# This currently works only for systems on EC2. Other systems should be
-# possible, but will require some work.
-# It has not yet been tested on Ubuntu
-
 # Assumptions (ENVVAR that overrides it):
-# * We want all ephemeral devices mounted as RAID0 (RAIDLEVEL) on /scratch0 (MOUNTPOINT)
 #   * Filesystem type is ext4 (FS_TYPE)
 #   * mkfs options are no journaling, and no root reservation (FS_OPTIONS, TUNE2FS_OPTIONS)
 #   * FS is labeled 'ephemeral-data' (FS_LABEL)
@@ -15,22 +10,27 @@
 # * We want ext4 (FS_TYPE)
 #   * tune2fs is set up to run always, this may not be appropriate for xfs and other fs types
 
-#TODO This should probably be a python script because of all the magic bashisms
-#  that are difficult to interpret by humans
-#     This needs safety precautions so that we don't accidentally wipe the boot
-#  volume or other EBS volumes that are mounted
-
-RAIDLEVEL=${RAIDLEVEL:-0}
-RAIDNAME=${RAIDNAME:-DATA}
 MOUNTPOINT=${MOUNTPOINT:-/scratch0}
-DEVICES=()
-NUM_DEVICES=
 FS_TYPE=${FS_TYPE:-ext4}
 FS_LABEL=${FS_LABEL:-ephemeral-data}
 FS_OPTIONS=${FS_OPTIONS:-"-q -O ^has_journal"}
 TUNE2FS_OPTIONS=${TUNE2FS_OPTIONS:-"-m 0"}
+
 #if defined, precede with a comma
 MOUNT_OPTIONS=${MOUNT_OPTIONS:-"defaults,data=writeback,noatime,nodiratime"}
+
+if [ -z "$SWARMYDIR" ]; then
+    echo "SWARMYDIR is not set, this script should be run from swarmy. Cowardly refusing to continue."
+    exit 1
+fi
+
+if [ ! -f "$SWARMYDIR/ephemeraldev" ]; then
+    echo "$SWARMYDIR/ephemeraldev does not exist, not sure where to format/mount"
+    exit 1
+fi
+
+read DEVICE < $SWARMYDIR/ephemeraldev
+
 
 function is_mounted() {
     thing=$1
@@ -46,113 +46,11 @@ function is_formatted() {
     return $?
 }
 
-function error {
-    echo $1
-    exit 1
-}
-
-#Find aws somewhere
-function find_aws {
-    if [ -z $AWSCMD ]; then
-        # This looks for aws cli in the VENV set up by swarmy, the VENV set up by
-        # ansible, or the PATH (system package or pip install)
-        for loc in /root/VENV/bin/aws /var/lib/crunch.io/venv/bin/aws $(which aws 2>/dev/null); do
-            if [ -x "$loc" ]; then
-                echo $loc
-                return 0
-            fi
-        done
-        error "No aws cli found in the common locations: aborting"
-    else
-        echo $AWSCMD
-    fi
-}
-
-AWSCMD=$(find_aws)
-
-function get_metadata {
-    curl -s http://169.254.169.254$1
-}
-
-# Check the "all done successfully" idempotent run
-#Assert that the $FS_LABEL exists, and is mounted
-LABELDEV=$(blkid -o value -s NAME -L $FS_LABEL || true)
-if [ -z "$FORCE" -a $? -eq 0 ] && is_mounted "$LABELDEV on $MOUNTPOINT"; then
-    exit 0
-fi
-
-if [ ! -d $MOUNTPOINT ]; then
-    mkdir -p $MOUNTPOINT
-fi
-
-
-#actually gets the av zone
-REGION=$(get_metadata /latest/meta-data/placement/availability-zone/)
-#remove the last char of the zone to get region
-REGION=${REGION%?}
-INSTANCE_ID=$(get_metadata /latest/meta-data/instance-id/)
-
-#Check to see what devices we need to mount
-#Get the list of EBS volumes mapped to the system
-EBS_VOLUMES=$($AWSCMD ec2 --region $REGION describe-instances --instance-ids $INSTANCE_ID  --query "Reservations[0].Instances[0].BlockDeviceMappings[*].DeviceName" --output text | sed -e 's#^/dev/sd\([a-z]\)[0-9]\+$#xvd\1#')
-
-#Get the list of block devices by name
-ALL_BLK_DEVICES=$(lsblk -ln -o NAME)
-for dev in $ALL_BLK_DEVICES; do
-    # NOTE: we assume that you won't have both on one system
-    case $dev in
-      nvme*)
-        DEVICES+=($dev)
-        ;;
-      xvd?)
-        #Make sure these are ephemeral, not EBS volumes
-        if ! [[ "$EBS_VOLUMES" =~ $dev[:digit:]? ]]; then
-            DEVICES+=($dev)
-        fi
-        ;;
-    esac
-done
-
-#length of the array
-NUM_DEVICES=${#DEVICES[@]}
-
-if [ "$NUM_DEVICES" -eq 1 ]; then
-    MDDEV=/dev/${DEVICES}
-else
-    MDDEV=/dev/md0
-fi
-
-# Undo/Force
-if [ -n "$FORCE" ]; then
-    # Unmount
-    if is_mounted $MOUNTPOINT; then
-        umount -f $MOUNTPOINT
-    fi
-
-    # Remove the fstab line
-    sed -i -e "\#.*\s$MOUNTPOINT\s.*#d" /etc/fstab
-
-    if [ "$NUM_DEVICES" -gt 1 ]; then
-        (
-        # Remove the mdadm.conf line
-        sed -i -e "\#.*\s$MDDEV\s.*#d" /etc/mdadm.conf || true
-
-        # Remove the Software Raid device
-        mdadm --stop $MDDEV || true
-        # Delete the device
-        mdadm --remove $MDDEV || true
-        # Remove them wiping their superblock
-        cd /dev
-        mdadm --zero-superblock ${DEVICES[@]} || true
-        )
-    fi
-fi
-
 #Precondition checks: Make sure we haven't been run
 (
     #Check to make sure we don't already have stuff mounted
-    if is_mounted "$MDDEV"; then
-        error "The mount device $MDDEV is already mounted"
+    if is_mounted "$DEVICE"; then
+        error "The mount device $DEVICE is already mounted"
     fi
 
     # Look at mount point to make sure nothing's mounted
@@ -164,38 +62,7 @@ fi
     if grep -q LABEL=$FS_LABEL /etc/fstab; then
         error "The mount point LABEL=$FS_LABEL is already listed in /etc/fstab"
     fi
-
-    # Look at mdadm.conf
-    if grep -q $MDDEV /etc/mdadm.conf; then
-        error "The mount device $MDDEV is already configured in /etc/mdadm.conf"
-    fi
-
-    #fix ephemeral, where mounted on /mnt
-    if is_mounted "/mnt"; then
-        umount -f /mnt
-        sed -i -e "\#.*\s/mnt\s.*#d" /etc/fstab
-        #WARNING, this wipes devices
-        for dev in ${DEVICES[@]}; do
-            dd if=/dev/zero of=/dev/$dev bs=10MB count=1
-        done
-    fi
 )
-
-if [ $NUM_DEVICES -gt 1 ]; then
-    if [ ! -f /usr/sbin/mdadm ]; then
-        error "mdadm tools not found"
-    fi
-# Do the work
-    #Make the RAID$RAIDLEVEL device
-    (
-        cd /dev
-        mdadm --create --verbose --level=$RAIDLEVEL $MDDEV --name=$RAIDNAME --raid-devices=$NUM_DEVICES ${DEVICES[@]}
-        mdadm --wait $MDDEV || true
-        mdadm --detail --scan >> /etc/mdadm.conf
-        blockdev --setra 65536 /dev/md0
-        echo $((30*1024)) > /proc/sys/dev/raid/speed_limit_min
-    )
-fi
 
 if [ -n "$FORCE" ] || ! is_formatted $MDDEV $FS_TYPE; then
     mkfs.$FS_TYPE -L $FS_LABEL $FS_OPTIONS $MDDEV
@@ -203,6 +70,7 @@ if [ -n "$FORCE" ] || ! is_formatted $MDDEV $FS_TYPE; then
         tune2fs $TUNE2FS_OPTIONS $MDDEV
     fi
 fi
+
 # mount via LABEL not device name, in case it changes
 echo LABEL=$FS_LABEL $MOUNTPOINT $FS_TYPE defaults,nofail,noatime,discard 0 2 >> /etc/fstab
 
@@ -211,6 +79,8 @@ mount $MOUNTPOINT
 
 #Assert that it's mounted
 if ! is_mounted "$MOUNTPOINT"; then
-    error "The mount point $MOUNTPOINT did not come up, aborting"
+    echo "The mount point $MOUNTPOINT did not come up, aborting"
+    exit 1
 fi
 
+touch $SWARMYDIR/mountephemeral.run

--- a/scripts/mountephemeral.sh
+++ b/scripts/mountephemeral.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -e
 
+# This script is meant to be chainloaded after prepephemeral.sh as it will use
+# the ephemeral device, create a filesystem on it and mount it on the the
+# mountpoint.
+
 # Assumptions (ENVVAR that overrides it):
 #   * Filesystem type is ext4 (FS_TYPE)
 #   * mkfs options are no journaling, and no root reservation (FS_OPTIONS, TUNE2FS_OPTIONS)

--- a/scripts/prepephemeral.sh
+++ b/scripts/prepephemeral.sh
@@ -1,0 +1,145 @@
+#!/bin/bash -e
+
+# This currently works only for systems on EC2. Other systems should be
+# possible, but will require some work.
+# It has not yet been tested on Ubuntu
+
+# Assumptions (ENVVAR that overrides it):
+# * We want all ephemeral devices mounted as RAID0 (RAIDLEVEL) on /scratch0 (MOUNTPOINT)
+#   * Filesystem type is ext4 (FS_TYPE)
+#   * mkfs options are no journaling, and no root reservation (FS_OPTIONS, TUNE2FS_OPTIONS)
+#   * FS is labeled 'ephemeral-data' (FS_LABEL)
+#   * Mount is set up in writeback mode, noatime nodiratime (MOUNT_OPTIONS)
+#     these may not work for non-ext4
+#   * No other setup is made (subdirs, etc)
+# * We want ext4 (FS_TYPE)
+#   * tune2fs is set up to run always, this may not be appropriate for xfs and other fs types
+
+#TODO This should probably be a python script because of all the magic bashisms
+#  that are difficult to interpret by humans
+#     This needs safety precautions so that we don't accidentally wipe the boot
+#  volume or other EBS volumes that are mounted
+
+RAIDLEVEL=${RAIDLEVEL:-0}
+RAIDNAME=${RAIDNAME:-data}
+DEVICES=()
+
+if [ -z "$SWARMYDIR" ]; then
+    echo "SWARMYDIR is not set, this script should be run from swarmy. Cowardly refusing to continue."
+    exit 1
+fi
+
+#Find aws somewhere
+function find_aws {
+
+    # If AWSCMD is not set, try to use command -v to find it, in $PATH
+    if [ -z "$AWSCMD" ]; then
+        AWSCMD=$(command -v aws)
+    fi
+
+    if [ -z "$AWSCMD" ]; then
+        # This looks for aws cli in the VENV set up by swarmy, the VENV set up by
+        # ansible, or the PATH (system package or pip install)
+        for loc in /root/VENV/bin/aws /var/lib/crunch.io/venv/bin/aws; do
+            if [ -x "$loc" ]; then
+                echo $loc
+                return 0
+            fi
+        done
+        echo "No aws cli found in the common locations: cowardly refusing to continue"
+        exit 1
+    else
+        echo "aws command found: $AWSCMD"
+    fi
+}
+
+AWSCMD=$(find_aws)
+
+function get_metadata {
+    curl -s http://169.254.169.254$1
+}
+
+#actually gets the av zone
+REGION=$(get_metadata /latest/meta-data/placement/availability-zone/)
+#remove the last char of the zone to get region
+REGION=${REGION%?}
+INSTANCE_ID=$(get_metadata /latest/meta-data/instance-id/)
+
+#Check to see what devices we need to mount
+#Get the list of EBS volumes mapped to the system
+EBS_VOLUMES=$($AWSCMD ec2 --region $REGION describe-instances --instance-ids $INSTANCE_ID  --query "Reservations[0].Instances[0].BlockDeviceMappings[*].DeviceName" --output text | sed -e 's#^/dev/sd\([a-z]\)[0-9]\+$#xvd\1#')
+
+#Get the list of block devices by name
+ALL_BLK_DEVICES=$(lsblk -ln -o NAME)
+for dev in $ALL_BLK_DEVICES; do
+    # NOTE: we assume that you won't have both on one system
+    case $dev in
+      nvme*)
+        DEVICES+=($dev)
+        ;;
+      xvd?)
+        #Make sure these are ephemeral, not EBS volumes
+        if ! [[ "$EBS_VOLUMES" =~ $dev[:digit:]? ]]; then
+            DEVICES+=($dev)
+        fi
+        ;;
+    esac
+done
+
+#length of the array
+NUM_DEVICES=${#DEVICES[@]}
+MDDEV=
+
+if [ "$NUM_DEVICES" -eq 1 ]; then
+    # If we only have a single device, we just move on
+    MDDEV=/dev/${DEVICES}
+    echo "We only found a single device. No further work necessary"
+else
+    MDDEV=/dev/md/${RAIDNAME}
+    MDADM=$(command -v mdadm)
+    BLOCKDEV=$(command -v blockdev)
+
+    if [ -z "$MDADM" -o -z "$BLOCKDEV" ]; then
+        echo "mdadm or blockdev tools not found. Cowardly exiting since we should be creating a md device."
+        exit 1
+    fi
+    # Verify that we haven't already been run...
+
+    # Look at mdadm.conf
+    if grep -q $MDDEV /etc/mdadm.conf; then
+        echo "The device $MDDEV is already configured in mdadm.conf. This script is a no-op."
+    elif [ -b $MDDEV ]; then
+        echo "The device $MDDEV already exists, but is not configured in mdadm.conf. Requires intervention to fix. Cowardly refusing to continue."
+        exit 2
+    else
+        # fix ephemeral, where mounted on /mnt
+        # WARNING, this wipes devices
+        for dev in ${DEVICES[@]}; do
+            if $(mount | grep -q "/dev/${dev}"); then
+                umount -f /dev/${dev}
+                dd if=/dev/zero of=/dev/$dev bs=10MB count=1
+                # Remove any /mnt mounts, which would the most likely cause for
+                # the above device to be mounted. Linux has so many ways to
+                # mount a device there is no clean/clear way to find out what
+                # /etc/fstab line refers to a device that is mounted
+                sed -i -e "\#.*\s/mnt\s.*#d" /etc/fstab
+            fi
+        done
+
+        # Do the work
+        # Make the RAID$RAIDLEVEL device
+        (
+            cd /dev
+            $MDADM --create --verbose --level=$RAIDLEVEL $MDDEV --name=$RAIDNAME --raid-devices=$NUM_DEVICES ${DEVICES[@]}
+            $MDADM --wait $MDDEV || true
+            $MDADM --detail --scan >> /etc/mdadm.conf
+            blockdev --setra 65536 $MDDEV
+            echo $((30*1024)) > /proc/sys/dev/raid/speed_limit_min
+        )
+fi
+
+if [ -n "$MDDEV" ]; then
+    echo -n "$MDDEV" > $SWARMYDIR/ephemeraldev
+fi
+touch $SWARMYDIR/prepephemeral.run
+

--- a/scripts/stage2.sh
+++ b/scripts/stage2.sh
@@ -18,5 +18,5 @@ dynamic_hostname $HOSTNAME_ARGS
 #fi
 if [ -n "$DEBUG" ]; then
     # This helps us to know that this was run completely
-    touch /root/stage-2.run
+    touch $SWARMYDIR/stage-2.run
 fi


### PR DESCRIPTION
This adds a couple of updates/new scripts:

1. It creates a new swarmy dotdir which can be used for cheap message passing/place to store the .run files to be able to see how far along things progressed before swarmy died
2. Redirects stdin/stdout in bootstrap.sh to files in the swarmy dotdir, this allows for debugging of the script when deployed to an aws host
3. Uses `pip install` to install `swarmy` and it's dependencies rather than using `python setup.py develop`
4. Adds new `prepephemeral.sh` script that does the prep-work (as necessary) to create a `md` device, it tries to exit as early as possible to avoid doing work it may not need to do.
5. Updates `mountephemeral.sh` to take the new `ephemeraldev` from the `prepephemeral.sh` script to mkfs/mount the ephemeral
6. Adds a new `dockerthinpool.sh` script that does the following:
   1. Creates a new LVM volumegroup
   2. Creates a new logical volume that is also a thinpool
   3. Creates the policy on how to extend it if we run out of space (and the thresholds for that)
   4. Tells the logical volume support sub-system to monitor for space usage and actually use the policy
   5. Creates a scratchspace logical volume that is then stored to `ephemeraldev` so that `mountephemeral.sh` can be chain-loaded and thus create any scratch volumes as necessary